### PR TITLE
Streamline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple Python-based VidMap draw tool for use with [vNAS](https://virtualnas.net).
 
-it is designed to be a stopgap for any facilities that do not have available vidmap data, or low traffic facilities that might not merit a FOIA request.
+It is designed to be a stopgap for any facilities that do not have available vidmap data, or low traffic facilities that might not merit a FOIA request.
 
 ## Testing Note
 
@@ -57,7 +57,7 @@ The fix object has the following properties, with the properties marked <span st
 - `frd_point`: A string in the format `"VOR/Radial/Distance"` (`"AML/135/12"`). This overrides `defined_by` but is overridden by `rnav_point`
 - `rnav_point`: A boolean value that tells the script to draw this point as an RNAV point symbol (four-pointed star). This overrides any defines in `defined_by` or `frd_point`.
 
-**NOTE**: If `defined_by` is omitted, the fix object will be drawn as a triangle rather than crossed lines.
+**NOTE**: If `defined_by`, `frd_point`, and `rnav_point` are not set, the fix will be drawn as a triangle.
 
 ### VOR Objects
 
@@ -79,7 +79,7 @@ The Restrictive object is an array of restrictive airspace names.
 - [The FAA doesn't appear to use Training airspace]
 - Warning, use the standard format of `W0[0000][A]` (W, followed by at least one number, and an optional letter, with no dashes)
 
-**NOTE**: Naming in the CIFP file is mostly standardized, but has some quirks, particularly for MOAs. It may be worth opening the CIFP file and searching for the entry. For example, Stumpy Point MOA appears in the file as STUMPY PT. If your program supports regex, you can search with `SUSAUR..M` and start typing the MOA name right after the `M`. For longer names, the name may actually be truncated. The Tombstone MOA, for example, is truncated as `TOMBSTON A`, `TOMBSTON B` amd `TOMBSTON C`.
+**NOTE**: Naming in the CIFP file is mostly standardized, but has some quirks, particularly for MOAs. It may be worth opening the CIFP file and searching for the entry. For example, Stumpy Point MOA appears in the file as STUMPY PT. If your program supports regex, you can search with `SUSAUR..M` and start typing the MOA name right after the `M` (e.g., `SUSAUR..MDEMO` for the DEMO MOA). For longer names, the name may actually be truncated. The Tombstone MOA, for example, is truncated as `TOMBSTON A`, `TOMBSTON B` amd `TOMBSTON C`.
 
 ## Drawing the Facility
 
@@ -89,7 +89,7 @@ Run the following command, where `AAA` is the FAA three letter identifier for th
 python3 draw.py --facility=[AAA]
 ```
 
-The resulting file will be in `./facilities/vidmaps`
+The resulting file will be in `./vidmaps`
 
 ### Additional Command Line Arguments
 

--- a/draw.py
+++ b/draw.py
@@ -11,7 +11,7 @@ def purgeNavData():
         fh.deleteAllInSubdir(".json", f"./navdata/{dir}")
 
 
-def processFacility(id):
+def processFacility(id: str):
     facility = Facility(id)
 
 

--- a/draw.py
+++ b/draw.py
@@ -6,9 +6,11 @@ import argparse
 
 def purgeNavData():
     fh = FileHandler()
-    dirs = ["airports", "fixes", "restrictive", "vors"]
+    dirs = ["restrictive"]
     for dir in dirs:
-        fh.deleteAllInSubdir(".json", f"./navdata/{dir}")
+        path = f"./navdata/{dir}"
+        if fh.checkPath(path):
+            fh.deleteAllInSubdir(".json", path)
 
 
 def processFacility(id: str):

--- a/modules/Airport.py
+++ b/modules/Airport.py
@@ -1,64 +1,50 @@
 from modules.Centerline import Centerline
 from modules.Circle import Circle
 from modules.CircleBarbs import CircleBarbs
-from modules.FileHandler import FileHandler
 from modules.Line import Line
-
-import json
-
-AIRPORT_DIR = "./navdata/airports"
 
 
 class Airport:
-    def __init__(self, magvar, airportObject):
+    def __init__(self, magvar: int, airportDefinition: dict, airportObject: dict):
         self.id = None
         self.magvar = magvar
         self.drawRunways = False
         self.drawCircle = True
         self.drawCricleBarbs = True
         self.centerlines = None
-        self.lat = None
-        self.lon = None
+        self.lat = 0
+        self.lon = 0
         self.runways = None
         self.pairedRunways = []
-        self.filePath = ""
         # Drawn Data
         self.featureArray = []
+        self.verifyAirportDefinition(airportDefinition)
         self.verifyAirportObject(airportObject)
-        self.getAirportData()
 
-    def verifyAirportObject(self, airportObject):
-        if airportObject:
-            if "id" in airportObject:
-                self.id = airportObject["id"]
-                self.filePath = f"{AIRPORT_DIR}/{self.id}.json"
-            if "runways" in airportObject:
-                self.drawRunways = airportObject["runways"]
-            if "symbol" in airportObject:
-                self.drawCircle = airportObject["symbol"]
-                self.drawCircleBarbs = airportObject["symbol"]
-            if "centerlines" in airportObject:
-                self.centerlines = airportObject["centerlines"]
+    def verifyAirportDefinition(self, airportDefinition: dict):
+        if "id" in airportDefinition:
+            self.id = airportDefinition["id"]
+        if "runways" in airportDefinition:
+            self.drawRunways = airportDefinition["runways"]
+        if "symbol" in airportDefinition:
+            self.drawCircle = airportDefinition["symbol"]
+            self.drawCircleBarbs = airportDefinition["symbol"]
+        if "centerlines" in airportDefinition:
+            self.centerlines = airportDefinition["centerlines"]
 
-    def getAirportData(self):
-        fh = FileHandler()
-        if fh.checkFile(self.filePath):
-            with open(self.filePath) as jsonFile:
-                airportData = json.load(jsonFile)
-                if "lat" in airportData:
-                    if type(airportData["lat"]) == float:
-                        self.lat = airportData["lat"]
-                if "lon" in airportData:
-                    if type(airportData["lon"]) == float:
-                        self.lon = airportData["lon"]
-                if "runways" in airportData:
-                    self.runways = airportData["runways"]
-                if "paired_runways" in airportData:
-                    self.pairedRunways = airportData["paired_runways"]
-                if not self.runways and not self.pairedRunways:
-                    self.drawRunways = False
-                    self.drawCircle = True
-                    self.drawCricleBarbs = True
+    def verifyAirportObject(self, airportObject: dict):
+        if "lat" in airportObject:
+            self.lat = airportObject["lat"]
+        if "lon" in airportObject:
+            self.lon = airportObject["lon"]
+        if "runways" in airportObject:
+            self.runways = airportObject["runways"]
+        if "paired_runways" in airportObject:
+            self.pairedRunways = airportObject["paired_runways"]
+        if not self.runways and not self.pairedRunways:
+            self.drawRunways = False
+            self.drawCircle = True
+            self.drawCricleBarbs = True
 
     def drawAirport(self):
         if self.lat and self.lon:

--- a/modules/Arc.py
+++ b/modules/Arc.py
@@ -6,16 +6,16 @@ import math
 class Arc:
     def __init__(
         self,
-        direction,
-        centerLat,
-        centerLon,
-        startLat,
-        startLon,
-        stopLat,
-        stopLon,
-        distance,
-        bearing,
-        angle,
+        direction: str,
+        centerLat: float,
+        centerLon: float,
+        startLat: float,
+        startLon: float,
+        stopLat: float,
+        stopLon: float,
+        distance: float,
+        bearing: float,
+        angle: float,
     ):
         self.direction = direction
         self.cCenter = Coordinate(centerLat, centerLon)

--- a/modules/Boundary.py
+++ b/modules/Boundary.py
@@ -7,7 +7,7 @@ BOUNDARY_DIR = "./boundaries"
 
 
 class Boundary:
-    def __init__(self, id):
+    def __init__(self, id: str):
         self.id = id
         self.filePath = f"{BOUNDARY_DIR}/{id}.json"
         self.featureArray = []

--- a/modules/CIFPAirport.py
+++ b/modules/CIFPAirport.py
@@ -1,8 +1,6 @@
 from modules.CIFPFunctions import CIFPFunctions
 from modules.Coordinate import Coordinate
 
-import json
-
 CIFP_AIRPORT_LINE = "A"
 CIFP_RUNWAY_LINE = "G"
 
@@ -97,9 +95,8 @@ class CIFPAirport:
         pairedRunway["baseLon"] = baseCoord.lon
         return pairedRunway
 
-    def toJsonFile(self, filePath):
+    def toDict(self):
         del self.cifpLines
         self.paired_runways = self.pairedRunways
         del self.pairedRunways
-        with open(filePath, "w") as jsonFile:
-            json.dump(self.__dict__, jsonFile)
+        return self.__dict__

--- a/modules/CIFPAirport.py
+++ b/modules/CIFPAirport.py
@@ -6,7 +6,7 @@ CIFP_RUNWAY_LINE = "G"
 
 
 class CIFPAirport:
-    def __init__(self, id, cifpLines):
+    def __init__(self, id: str, cifpLines: list):
         self.id = id
         self.lat = None
         self.lon = None
@@ -26,10 +26,10 @@ class CIFPAirport:
                 self.lon = coord.lon
                 self.magvar = cf.convertMagVar(line[51:56])
 
-    def findRunway(self, runwayId, runways):
+    def findRunway(self, runwayId: str, runways: list):
         return [runway for runway in runways if runway.get("id") == runwayId][0]
 
-    def invertRunwayId(self, runwayId):
+    def invertRunwayId(self, runwayId: str):
         inverseRunwayId = ""
         inverseRunwayPos = ""
         mainId = runwayId[2:4]
@@ -83,7 +83,7 @@ class CIFPAirport:
             pairedRunways.append(pairedRunway)
         self.pairedRunways = pairedRunways
 
-    def undisplaceThreshold(self, pairedRunway, displacement):
+    def undisplaceThreshold(self, pairedRunway: dict, displacement: float):
         FEET_IN_NM = 6076.12
         baseCoord = Coordinate(pairedRunway["baseLat"], pairedRunway["baseLon"])
         recipCoord = Coordinate(pairedRunway["recipLat"], pairedRunway["recipLon"])

--- a/modules/CIFPFix.py
+++ b/modules/CIFPFix.py
@@ -1,7 +1,5 @@
 from modules.CIFPFunctions import CIFPFunctions
 
-import json
-
 
 class CIFPFix:
     def __init__(self, id, cifpLine):
@@ -19,7 +17,6 @@ class CIFPFix:
         self.lon = coord.lon
         self.magvar = cf.convertMagVar(self.cifpLine[74:79])
 
-    def toJsonFile(self, filePath):
+    def toDict(self):
         del self.cifpLine
-        with open(filePath, "w") as jsonFile:
-            json.dump(self.__dict__, jsonFile)
+        return self.__dict__

--- a/modules/CIFPFix.py
+++ b/modules/CIFPFix.py
@@ -2,7 +2,7 @@ from modules.CIFPFunctions import CIFPFunctions
 
 
 class CIFPFix:
-    def __init__(self, id, cifpLine):
+    def __init__(self, id: str, cifpLine: str):
         self.id = id
         self.lat = None
         self.lon = None

--- a/modules/CIFPFunctions.py
+++ b/modules/CIFPFunctions.py
@@ -2,7 +2,7 @@ from modules.Coordinate import Coordinate
 
 
 class CIFPFunctions:
-    def convertDMS(self, cifpDMSSubstring):
+    def convertDMS(self, cifpDMSSubstring: str):
         latString = cifpDMSSubstring[0:9]
         lonString = cifpDMSSubstring[9:19]
         northSouth = latString[0:1]
@@ -17,7 +17,7 @@ class CIFPFunctions:
         coord.fromDMS(northSouth, latD, latM, latS, eastWest, lonD, lonM, lonS)
         return coord
 
-    def convertMagVar(self, cifpMagVarSubstring):
+    def convertMagVar(self, cifpMagVarSubstring: str):
         magVarValue = int(cifpMagVarSubstring[1:]) / 10
         if cifpMagVarSubstring[0:1] == "W":
             magVarValue = -magVarValue

--- a/modules/CIFPRestrictive.py
+++ b/modules/CIFPRestrictive.py
@@ -8,7 +8,7 @@ RHUMB_LINE = "H"
 
 
 class CIFPRestrictive:
-    def __init__(self, id, cifpLines):
+    def __init__(self, id: str, cifpLines: list):
         self.id = id
         self.definitions = []
         self.cifpLines = cifpLines

--- a/modules/CIFPRestrictive.py
+++ b/modules/CIFPRestrictive.py
@@ -1,7 +1,5 @@
 from modules.CIFPFunctions import CIFPFunctions
 
-import json
-
 CIRCLE = "C"
 CLOCKWISE_ARC = "R"
 COUNTER_CLOCKWISE_ARC = "L"
@@ -100,8 +98,7 @@ class CIFPRestrictive:
             sectionObject = {"definition": sectionDefinition}
             self.definitions.append(sectionObject)
 
-    def toJsonFile(self, filePath):
+    def toDict(self):
         del self.cifpLines
         del self.sectionedLines
-        with open(filePath, "w") as jsonFile:
-            json.dump(self.__dict__, jsonFile)
+        return self.__dict__

--- a/modules/CIFPVOR.py
+++ b/modules/CIFPVOR.py
@@ -2,7 +2,7 @@ from modules.CIFPFunctions import CIFPFunctions
 
 
 class CIFPVOR:
-    def __init__(self, id, cifpLine):
+    def __init__(self, id: str, cifpLine: str):
         self.id = id
         self.lat = None
         self.lon = None

--- a/modules/CIFPVOR.py
+++ b/modules/CIFPVOR.py
@@ -1,7 +1,5 @@
 from modules.CIFPFunctions import CIFPFunctions
 
-import json
-
 
 class CIFPVOR:
     def __init__(self, id, cifpLine):
@@ -22,7 +20,6 @@ class CIFPVOR:
         self.lon = coord.lon
         self.magvar = cf.convertMagVar(self.cifpLine[74:79])
 
-    def toJsonFile(self, filePath):
+    def toDict(self):
         del self.cifpLine
-        with open(filePath, "w") as jsonFile:
-            json.dump(self.__dict__, jsonFile)
+        return self.__dict__

--- a/modules/Centerline.py
+++ b/modules/Centerline.py
@@ -4,7 +4,9 @@ from modules.Line import Line
 
 
 class Centerline:
-    def __init__(self, runwayId, pairedRunways, length, crossbars):
+    def __init__(
+        self, runwayId: str, pairedRunways: list, length: int, crossbars: list
+    ):
         self.runwayId = runwayId
         self.pairedRunways = pairedRunways
         self.length = length

--- a/modules/Circle.py
+++ b/modules/Circle.py
@@ -2,7 +2,9 @@ from modules.Coordinate import Coordinate
 
 
 class Circle:
-    def __init__(self, lat, lon, sides, radius, rotation=0):
+    def __init__(
+        self, lat: float, lon: float, sides: int, radius: float, rotation: float = 0
+    ):
         self.lat = lat
         self.lon = lon
         self.sides = sides

--- a/modules/CircleBarbs.py
+++ b/modules/CircleBarbs.py
@@ -2,7 +2,15 @@ from modules.Coordinate import Coordinate
 
 
 class CircleBarbs:
-    def __init__(self, lat, lon, barbs, length, radius, rotation=0):
+    def __init__(
+        self,
+        lat: float,
+        lon: float,
+        barbs: int,
+        length: float,
+        radius: float,
+        rotation: float = 0,
+    ):
         self.lat = lat
         self.lon = lon
         self.barbs = barbs

--- a/modules/Coordinate.py
+++ b/modules/Coordinate.py
@@ -5,11 +5,21 @@ EARTH_RADIUS_NM = 3443.92
 
 
 class Coordinate:
-    def __init__(self, lat=0.0, lon=0.0):
+    def __init__(self, lat: float = 0.0, lon: float = 0.0):
         self.lat = lat
         self.lon = lon
 
-    def fromDMS(self, northSouth, latD, latM, latS, eastWest, lonD, lonM, lonS):
+    def fromDMS(
+        self,
+        northSouth: str,
+        latD: int,
+        latM: int,
+        latS: float,
+        eastWest: str,
+        lonD: int,
+        lonM: int,
+        lonS: float,
+    ):
         lat = latD + (latM / 60) + (latS / (60 * 60))
         if northSouth == "S":
             lat = -lat
@@ -19,7 +29,7 @@ class Coordinate:
         self.lat = lat
         self.lon = lon
 
-    def fromPBD(self, lat, lon, bearing, distance):
+    def fromPBD(self, lat: float, lon: float, bearing: float, distance: float):
         endLat = math.asin(
             math.sin(math.radians(lat)) * math.cos(distance / EARTH_RADIUS_NM)
             + math.cos(math.radians(lat))
@@ -36,7 +46,7 @@ class Coordinate:
         self.lat = math.degrees(endLat)
         self.lon = math.degrees(endLon)
 
-    def haversineGreatCicleDistance(self, endLat, endLon):
+    def haversineGreatCicleDistance(self, endLat: float, endLon: float):
         theta = self.lon - endLon
         arc = math.degrees(
             math.acos(
@@ -51,7 +61,7 @@ class Coordinate:
         distance = arc * DEG_TO_MIN
         return distance
 
-    def haversineGreatCircleBearing(self, endLat, endLon):
+    def haversineGreatCircleBearing(self, endLat: float, endLon: float):
         x = math.cos(math.radians(self.lat)) * math.sin(
             math.radians(endLat)
         ) - math.sin(math.radians(self.lat)) * math.cos(

--- a/modules/Cross.py
+++ b/modules/Cross.py
@@ -1,30 +1,27 @@
 from modules.Coordinate import Coordinate
 from modules.Line import Line
-from modules.VOR import VOR
 
 import math
 
 
 class Cross:
-    def __init__(self, lat, lon, length, defines):
+    def __init__(self, lat: float, lon: float, lineLength: float, defines: list):
         self.lat = lat
         self.lon = lon
-        self.length = length
+        self.lineLength = lineLength
         self.defines = defines
         self.featureArray = []
         self.draw()
 
     def draw(self):
-        for point in self.defines:
-            vorObject = {"id": point}
-            vor = VOR(0, vorObject)
-            if type(vor.lat) == float and type(vor.lon) == float:
+        for vor in self.defines:
+            if "id" in vor and "lat" in vor and "lon" in vor:
                 innerPoint = Coordinate(self.lat, self.lon)
                 outerPoint = Coordinate(self.lat, self.lon)
-                bearing = innerPoint.haversineGreatCircleBearing(vor.lat, vor.lon)
-                innerPoint.fromPBD(self.lat, self.lon, bearing, self.length * 0.5)
+                bearing = innerPoint.haversineGreatCircleBearing(vor["lat"], vor["lon"])
+                innerPoint.fromPBD(self.lat, self.lon, bearing, self.lineLength * 0.5)
                 bearing = math.fmod(bearing + 180, 360)
-                outerPoint.fromPBD(self.lat, self.lon, bearing, self.length * 0.5)
+                outerPoint.fromPBD(self.lat, self.lon, bearing, self.lineLength * 0.5)
                 line = Line(
                     innerPoint.lat, innerPoint.lon, outerPoint.lat, outerPoint.lon
                 )

--- a/modules/Crossbar.py
+++ b/modules/Crossbar.py
@@ -5,11 +5,11 @@ import math
 
 
 class Crossbar:
-    def __init__(self, lat, lon, bearing, length):
+    def __init__(self, lat: float, lon: float, bearing: float, lineLength: float):
         self.lat = lat
         self.lon = lon
         self.bearing = bearing
-        self.length = length
+        self.lineLength = lineLength
         self.feature = None
         self.draw()
 
@@ -18,8 +18,8 @@ class Crossbar:
         bearing = math.fmod(self.bearing + PERPENDICULAR_ANGLE, 360)
         point1 = Coordinate(self.lat, self.lon)
         point2 = Coordinate(self.lat, self.lon)
-        point1.fromPBD(self.lat, self.lon, bearing, self.length * 0.5)
+        point1.fromPBD(self.lat, self.lon, bearing, self.lineLength * 0.5)
         bearing = math.fmod(bearing + 180, 360)
-        point2.fromPBD(self.lat, self.lon, bearing, self.length * 0.5)
+        point2.fromPBD(self.lat, self.lon, bearing, self.lineLength * 0.5)
         line = Line(point1.lat, point1.lon, point2.lat, point2.lon)
         self.feature = line.feature

--- a/modules/FRD.py
+++ b/modules/FRD.py
@@ -1,57 +1,48 @@
-from modules.Converter import Converter
 from modules.Coordinate import Coordinate
 from modules.Line import Line
-from modules.VOR import VOR
 
 import math
 
 
 class FRD:
-    def __init__(self, length, define):
-        self.length = length
-        self.define = define
+    def __init__(
+        self,
+        originLat: float,
+        originLon: float,
+        radial: float,
+        distance: float,
+        lineLength: float,
+    ):
+        self.lat = originLat
+        self.lon = originLon
+        self.radial = radial
+        self.distance = distance
+        self.lineLength = lineLength
         self.featureArray = []
         self.draw()
 
     def draw(self):
-        conv = Converter()
-        defineArray = self.define.split("/")
-        vorId = defineArray[0]
-        radial = conv.tryFloatParse(defineArray[1])
-        distance = conv.tryFloatParse(defineArray[2])
-        if (
-            type(vorId) == str
-            and (type(radial) == int or type(radial) == float)
-            and (type(distance) == int or type(distance) == float)
-        ):
-            vorObject = {"id": defineArray[0]}
-            vor = VOR(0, vorObject)
-            if type(vor.lat) == float and type(vor.lon) == float:
-                crossPoint = Coordinate()
-                crossPoint.fromPBD(vor.lat, vor.lon, radial, distance)
-                innerPoint = Coordinate(crossPoint.lat, crossPoint.lon)
-                outerPoint = Coordinate(crossPoint.lat, crossPoint.lon)
-                bearing = radial
-                innerPoint.fromPBD(
-                    crossPoint.lat, crossPoint.lon, bearing, self.length * 0.5
-                )
-                bearing = math.fmod(bearing + 180, 360)
-                outerPoint.fromPBD(
-                    crossPoint.lat, crossPoint.lon, bearing, self.length * 0.5
-                )
-                line = Line(
-                    innerPoint.lat, innerPoint.lon, outerPoint.lat, outerPoint.lon
-                )
-                self.featureArray.append(line.feature)
-                bearing = math.fmod(bearing + 90, 360)
-                innerPoint.fromPBD(
-                    crossPoint.lat, crossPoint.lon, bearing, self.length * 0.5
-                )
-                bearing = math.fmod(bearing + 180, 360)
-                outerPoint.fromPBD(
-                    crossPoint.lat, crossPoint.lon, bearing, self.length * 0.5
-                )
-                line = Line(
-                    innerPoint.lat, innerPoint.lon, outerPoint.lat, outerPoint.lon
-                )
-                self.featureArray.append(line.feature)
+        crossPoint = Coordinate()
+        crossPoint.fromPBD(self.lat, self.lon, self.radial, self.distance)
+        innerPoint = Coordinate(crossPoint.lat, crossPoint.lon)
+        outerPoint = Coordinate(crossPoint.lat, crossPoint.lon)
+        bearing = self.radial
+        innerPoint.fromPBD(
+            crossPoint.lat, crossPoint.lon, bearing, self.lineLength * 0.5
+        )
+        bearing = math.fmod(bearing + 180, 360)
+        outerPoint.fromPBD(
+            crossPoint.lat, crossPoint.lon, bearing, self.lineLength * 0.5
+        )
+        line = Line(innerPoint.lat, innerPoint.lon, outerPoint.lat, outerPoint.lon)
+        self.featureArray.append(line.feature)
+        bearing = math.fmod(bearing + 90, 360)
+        innerPoint.fromPBD(
+            crossPoint.lat, crossPoint.lon, bearing, self.lineLength * 0.5
+        )
+        bearing = math.fmod(bearing + 180, 360)
+        outerPoint.fromPBD(
+            crossPoint.lat, crossPoint.lon, bearing, self.lineLength * 0.5
+        )
+        line = Line(innerPoint.lat, innerPoint.lon, outerPoint.lat, outerPoint.lon)
+        self.featureArray.append(line.feature)

--- a/modules/FileHandler.py
+++ b/modules/FileHandler.py
@@ -5,14 +5,14 @@ class FileHandler:
     def __init__(self):
         self.localPath = os.getcwd()
 
-    def checkFile(self, filePathFromRoot):
+    def checkFile(self, filePathFromRoot: str):
         result = False
         filePath = self.localPath + "/" + filePathFromRoot
         if os.path.exists(filePath):
             result = True
         return result
 
-    def checkDir(self, subdirPath):
+    def checkDir(self, subdirPath: str):
         result = False
         dirPath = self.localPath + "/" + subdirPath
         os.makedirs(name=dirPath, exist_ok=True)
@@ -20,21 +20,21 @@ class FileHandler:
             result = True
         return result
 
-    def deleteAllInSubdir(self, fileType, subdirPath=None):
+    def deleteAllInSubdir(self, fileType: str, subdirPath: str = ""):
         # As it stands, this will only ever delete items in the named subfolder where this script runs.
         # Altering this function could cause it to delete the entire contents of other folders where you wouldn't want it to.
         # Alter this at your own risk.
-        if subdirPath != None:
+        if subdirPath != "":
             deletePath = self.localPath + "/" + subdirPath
             if os.path.exists(deletePath):
                 for f in os.listdir(deletePath):
                     if f.endswith(fileType):
                         os.remove(os.path.join(deletePath, f))
 
-    def searchForType(self, fileType, subdirPath=None):
+    def searchForType(self, fileType: str, subdirPath: str = ""):
         result = []
         searchPath = self.localPath
-        if subdirPath != None:
+        if subdirPath != "":
             searchPath += "/" + subdirPath
         for dirpath, subdirs, files in os.walk(searchPath):
             result.extend(
@@ -42,11 +42,11 @@ class FileHandler:
             )
         return result
 
-    def splitFolderFile(self, fullPath, subdirPath=None):
+    def splitFolderFile(self, fullPath: str, subdirPath: str = ""):
         result = []
         split = os.path.split(fullPath)
         searchPath = self.localPath
-        if subdirPath != None:
+        if subdirPath != "":
             searchPath += "/" + subdirPath
         result.append(split[0].replace(searchPath, ""))
         result.append(split[1])

--- a/modules/FileHandler.py
+++ b/modules/FileHandler.py
@@ -5,6 +5,13 @@ class FileHandler:
     def __init__(self):
         self.localPath = os.getcwd()
 
+    def checkPath(self, pathFromRoot: str):
+        result = False
+        path = self.localPath + "/" + pathFromRoot
+        if os.path.exists(path):
+            result = True
+        return result
+
     def checkFile(self, filePathFromRoot: str):
         result = False
         filePath = self.localPath + "/" + filePathFromRoot

--- a/modules/Fix.py
+++ b/modules/Fix.py
@@ -1,77 +1,93 @@
 from modules.Circle import Circle
+from modules.Converter import Converter
 from modules.Cross import Cross
-from modules.FileHandler import FileHandler
 from modules.FRD import FRD
 from modules.RNAV import RNAV
 
-import json
-
-FIX_DIR = "./navdata/fixes"
-
 
 class Fix:
-    def __init__(self, magvar, fixObject):
+    def __init__(
+        self, magvar: int, fixDefinition: dict, fixObject: dict, cifpVors: list = []
+    ):
         self.id = None
         self.magvar = magvar
-        self.definedBy = None
-        self.rnavPoint = None
-        self.frdPoint = None
-        self.lat = None
-        self.lon = None
-        self.filePath = ""
+        self.definedBy = []
+        self.rnavPoint = False
+        self.frdPoint = ""
+        self.cifpVors = cifpVors
+        self.lat = 0
+        self.lon = 0
         # Drawn Data
         self.featureArray = []
+        self.verifyFixDefinition(fixDefinition)
         self.verifyFixObject(fixObject)
-        self.getFixData()
 
-    def verifyFixObject(self, fixObject):
-        if fixObject:
-            if "id" in fixObject:
-                self.id = fixObject["id"]
-                self.filePath = f"{FIX_DIR}/{self.id}.json"
-            if "defined_by" in fixObject:
-                self.definedBy = fixObject["defined_by"]
-            if "rnav_point" in fixObject:
-                self.rnavPoint = fixObject["rnav_point"]
-            if "frd_point" in fixObject:
-                self.frdPoint = fixObject["frd_point"]
+    def verifyFixDefinition(self, fixDefinition: dict):
+        if "id" in fixDefinition:
+            self.id = fixDefinition["id"]
+        if "defined_by" in fixDefinition:
+            self.definedBy = fixDefinition["defined_by"]
+        if "rnav_point" in fixDefinition:
+            self.rnavPoint = fixDefinition["rnav_point"]
+        if "frd_point" in fixDefinition:
+            self.frdPoint = fixDefinition["frd_point"]
 
-    def getFixData(self):
-        fh = FileHandler()
-        if fh.checkFile(self.filePath):
-            with open(self.filePath) as jsonFile:
-                fixData = json.load(jsonFile)
-                if "lat" in fixData:
-                    if type(fixData["lat"]) == float:
-                        self.lat = fixData["lat"]
-                if "lon" in fixData:
-                    if type(fixData["lon"]) == float:
-                        self.lon = fixData["lon"]
+    def verifyFixObject(self, fixObject: dict):
+        if "id" in fixObject:
+            self.id = fixObject["id"]
+        if "lat" in fixObject:
+            self.lat = fixObject["lat"]
+        if "lon" in fixObject:
+            self.lon = fixObject["lon"]
+
+    def drawBasic(self):
+        SIDES = 3
+        RADIUS = 0.2
+        triangle = Circle(self.lat, self.lon, SIDES, RADIUS, self.magvar)
+        self.featureArray.append(triangle.feature)
+
+    def drawRNAV(self):
+        SIDES = 24
+        RADIUS = 0.3
+        rnavPoint = RNAV(self.lat, self.lon, SIDES, RADIUS, self.magvar)
+        for feature in rnavPoint.featureArray:
+            self.featureArray.append(feature)
+
+    def drawFRD(self):
+        conv = Converter()
+        defineArray = self.frdPoint.split("/")
+        vorId = defineArray[0]
+        radial = conv.tryFloatParse(defineArray[1])
+        distance = conv.tryFloatParse(defineArray[2])
+        for vor in self.cifpVors:
+            if (
+                "id" in vor
+                and "lat" in vor
+                and "lon" in vor
+                and vor["id"] == vorId
+                and type(radial) == float
+                and type(distance) == float
+            ):
+                LENGTH = 1
+                frd = FRD(vor["lat"], vor["lon"], radial, distance, LENGTH)
+                for feature in frd.featureArray:
+                    self.featureArray.append(feature)
+
+    def drawDefinedBy(self):
+        LENGTH = 1
+        cross = Cross(self.lat, self.lon, LENGTH, self.definedBy)
+        for feature in cross.featureArray:
+            self.featureArray.append(feature)
 
     def drawFix(self):
         if (self.lat != None and self.lon != None) or (self.frdPoint != None):
             if self.rnavPoint == True:
-                SIDES = 24
-                RADIUS = 0.3
-                rnavPoint = RNAV(self.lat, self.lon, SIDES, RADIUS, self.magvar)
-                for feature in rnavPoint.featureArray:
-                    self.featureArray.append(feature)
+                self.drawRNAV()
             else:
                 if self.frdPoint:
-                    LENGTH = 1
-                    frd = FRD(LENGTH, self.frdPoint)
-                    for feature in frd.featureArray:
-                        self.featureArray.append(feature)
+                    self.drawFRD()
                 else:
                     if self.definedBy:
-                        LENGTH = 1
-                        cross = Cross(self.lat, self.lon, LENGTH, self.definedBy)
-                        for feature in cross.featureArray:
-                            self.featureArray.append(feature)
+                        self.drawDefinedBy()
                     else:
-                        SIDES = 3
-                        RADIUS = 0.2
-                        triangle = Circle(
-                            self.lat, self.lon, SIDES, RADIUS, self.magvar
-                        )
-                        self.featureArray.append(triangle.feature)
+                        self.drawBasic()

--- a/modules/Line.py
+++ b/modules/Line.py
@@ -1,5 +1,5 @@
 class Line:
-    def __init__(self, startLat, startLon, endLat, endLon):
+    def __init__(self, startLat: float, startLon: float, endLat: float, endLon: float):
         self.startLat = startLat
         self.startLon = startLon
         self.endLat = endLat

--- a/modules/RNAV.py
+++ b/modules/RNAV.py
@@ -4,7 +4,9 @@ from modules.Circle import Circle
 
 
 class RNAV:
-    def __init__(self, lat, lon, sides, radius, rotation=0):
+    def __init__(
+        self, lat: float, lon: float, sides: int, radius: float, rotation: float = 0
+    ):
         self.lat = lat
         self.lon = lon
         self.sides = sides

--- a/modules/RNAVArc.py
+++ b/modules/RNAVArc.py
@@ -2,7 +2,16 @@ from modules.Coordinate import Coordinate
 
 
 class RNAVArc:
-    def __init__(self, lat, lon, sides, radius, fromDegree, toDegree, rotation=0):
+    def __init__(
+        self,
+        lat: float,
+        lon: float,
+        sides: int,
+        radius: float,
+        fromDegree: float,
+        toDegree: float,
+        rotation: float = 0,
+    ):
         self.lat = lat
         self.lon = lon
         self.sides = sides

--- a/modules/Restrictive.py
+++ b/modules/Restrictive.py
@@ -1,7 +1,5 @@
 from modules.Arc import Arc
 from modules.Circle import Circle
-from modules.FileHandler import FileHandler
-from modules.Line import Line
 
 import json
 import math
@@ -10,27 +8,28 @@ CIRCLE_LINE_LENGTH = 0.349030413029316  # This is desired line length at an angl
 ARC_LINE_LENGTH = 1.74515206514658  # This is desired line length at an angle corresponding to 10* at 10NM
 DEGREES_IN_CIRCLE = 360
 
-RESTRICTIVE_DIR = "./navdata/restrictive"
+NAVDATA_DIR = "./navdata"
+RESTRICTIVE_DIR = f"{NAVDATA_DIR}/restrictive"
 
 
 class Restrictive:
-    def __init__(self, restId):
-        self.id = restId
-        self.filePath = f"{RESTRICTIVE_DIR}/{self.id}.json"
+    def __init__(self, restObject: dict):
+        self.id = None
+        self.filePath = ""
         self.definitionsArray = []
         # Drawn Data
         self.featureArray = []
-        self.getRestData()
+        self.verifyRestObject(restObject)
 
-    def getRestData(self):
-        fh = FileHandler()
-        if fh.checkFile(self.filePath):
-            with open(self.filePath) as jsonFile:
-                restData = json.load(jsonFile)
-                if "definitions" in restData:
-                    self.definitionsArray = restData["definitions"]
+    def verifyRestObject(self, restObject: dict):
+        print(restObject)
+        if "id" in restObject:
+            self.id = restObject["id"]
+            self.filePath = f"{RESTRICTIVE_DIR}/{self.id}.json"
+        if "definitions" in restObject:
+            self.definitionsArray = restObject["definitions"]
 
-    def drawCircle(self, typeObject):
+    def drawCircle(self, typeObject: dict):
         if "center" in typeObject and "distance" in typeObject:
             center = typeObject["center"]
             lat = float(center[0])
@@ -42,7 +41,7 @@ class Restrictive:
             circle = Circle(lat, lon, sides, dist)
             self.featureArray.append(circle.feature)
 
-    def drawArc(self, typeObject):
+    def drawArc(self, typeObject: dict):
         coordinates = []
         if (
             "direction" in typeObject
@@ -74,7 +73,7 @@ class Restrictive:
             coordinates = arc.coordinates
         return coordinates
 
-    def drawLine(self, typeObject):
+    def drawLine(self, typeObject: dict):
         result = None
         if "point" in typeObject:
             coord = typeObject["point"]
@@ -82,7 +81,7 @@ class Restrictive:
             result = [coord[1], coord[0]]
         return result
 
-    def drawDefinition(self, definition):
+    def drawDefinition(self, definition: dict):
         coordinates = []
         for item in definition:
             if "type" in item:
@@ -120,3 +119,8 @@ class Restrictive:
             if "definition" in definitions:
                 definition = definitions["definition"]
                 self.drawDefinition(definition)
+        self.toJsonFile()
+
+    def toJsonFile(self):
+        with open(self.filePath, "w") as jsonFile:
+            json.dump(self.featureArray, jsonFile)

--- a/modules/VOR.py
+++ b/modules/VOR.py
@@ -1,41 +1,31 @@
 from modules.Circle import Circle
-from modules.FileHandler import FileHandler
-
-import json
-
-VOR_DIR = "./navdata/vors"
 
 
 class VOR:
-    def __init__(self, magvar, vorObject):
+    def __init__(self, magvar: int, vorDefinition: dict, vorObject: dict):
         self.id = None
         self.magvar = magvar
         self.innerOnly = False
-        self.lat = None
-        self.lon = None
-        self.filePath = ""
+        self.lat = 0
+        self.lon = 0
         # Drawn Data
         self.featureArray = []
+        self.verifyVORDefinition(vorDefinition)
         self.verifyVORObject(vorObject)
-        self.getVORData()
 
-    def verifyVORObject(self, vorObject):
-        if vorObject:
-            if "id" in vorObject:
-                self.id = vorObject["id"]
-                self.filePath = f"{VOR_DIR}/{self.id}.json"
-            if "inner_only" in vorObject:
-                self.innerOnly = vorObject["inner_only"]
+    def verifyVORDefinition(self, vorDefinition: dict):
+        if "id" in vorDefinition:
+            self.id = vorDefinition["id"]
+        if "inner_only" in vorDefinition:
+            self.innerOnly = vorDefinition["inner_only"]
 
-    def getVORData(self):
-        fh = FileHandler()
-        if fh.checkFile(self.filePath):
-            with open(self.filePath) as jsonFile:
-                vorData = json.load(jsonFile)
-                if "lat" in vorData:
-                    self.lat = vorData["lat"]
-                if "lon" in vorData:
-                    self.lon = vorData["lon"]
+    def verifyVORObject(self, vorObject: dict):
+        if "id" in vorObject:
+            self.id = vorObject["id"]
+        if "lat" in vorObject:
+            self.lat = vorObject["lat"]
+        if "lon" in vorObject:
+            self.lon = vorObject["lon"]
 
     def drawVOR(self):
         SIDES = 24

--- a/vidmaps/.gitignore
+++ b/vidmaps/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Streamline the handling of navdata:
- Pass dicts instead saving and reading files
- Set all CIFP data in a single pass instead of a pass per object type
- Save the processed Restrictive data to save on expensive calculations